### PR TITLE
Fix bullet point formatting in lists

### DIFF
--- a/_sass/_basic.scss
+++ b/_sass/_basic.scss
@@ -153,7 +153,7 @@ p, ul, ol {
 }
 
 ul, ol {
-	list-style-position: inside;
+	list-style-position: outside;
 }
 
 blockquote {


### PR DESCRIPTION
## Problem

Bullet points in lists were appearing on a separate line from their text content, especially noticeable in the "Participate in the Open" article with longer list items.

## Lösung

Changed `list-style-position` from `inside` to `outside` in `_sass/_basic.scss`.

- ✅ Bullet points now appear on the same line as their text
- ✅ Tested locally with Jekyll Docker container
- ✅ Improves readability of all list items across the site

## Before
Bullet (•) on one line
Text starting on the next line

## After
• Bullet and text on the same line

🤖 Generated with [Claude Code](https://claude.com/claude-code)