### PR TITLE
fix: upgrade jekyll to 3.9.1 to fix security vulnerabilities

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'jekyll', '3.9.0'
+gem 'jekyll', '3.9.1'
 
 group :jekyll_plugins do
   gem 'jekyll-paginate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,20 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.3)
-      public_suffix (>= 2.0.2, < 6.0)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
     colorator (1.1.0)
-    concurrent-ruby (1.2.2)
+    concurrent-ruby (1.3.5)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
-    ffi (1.15.5)
+    ffi (1.16.3)
     forwardable-extended (2.6.0)
     http_parser.rb (0.8.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    jekyll (3.9.0)
+    jekyll (3.9.1)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
@@ -34,22 +34,22 @@ GEM
       jekyll (>= 3.7, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    kramdown (2.4.0)
-      rexml
+    kramdown (2.5.1)
+      rexml (>= 3.3.9)
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liquid (4.0.4)
-    listen (3.8.0)
+    listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (5.0.1)
+    public_suffix (5.1.1)
     rb-fsevent (0.11.2)
-    rb-inotify (0.10.1)
+    rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rexml (3.2.5)
+    rexml (3.4.1)
     rouge (3.30.0)
     safe_yaml (1.0.5)
     sass (3.7.4)
@@ -63,7 +63,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  jekyll (= 3.9.0)
+  jekyll (= 3.9.1)
   jekyll-paginate
   jekyll-sitemap
   kramdown-parser-gfm


### PR DESCRIPTION
## Summary
Upgrades Jekyll from 3.9.0 to 3.9.1 to fix 6 security vulnerabilities in dependencies.

## Fixed Vulnerabilities
- **HIGH**: Improper Restriction of XML External Entity Reference (XXE) in rexml (Score: 624)
- **MEDIUM**: Uncontrolled Resource Consumption in rexml (Score: 666)
- **MEDIUM**: Denial of Service (DoS) in rexml (Score: 559)
- **MEDIUM**: Regular Expression Denial of Service (ReDoS) in rexml (Score: 559)
- **MEDIUM**: Uncontrolled Resource Consumption in rexml (Score: 479)
- **MEDIUM**: Denial of Service (DoS) in rexml (Score: 479)

## Changes
- Upgrades jekyll from 3.9.0 to 3.9.1 (patch update, backwards compatible)
- Upgrades rexml from 3.2.5 to 3.4.1
- Upgrades kramdown from 2.4.0 to 2.5.1 with explicit `rexml >= 3.3.9` requirement
- Updates other dependencies to latest compatible versions

## Testing
This is a patch update that should be fully backwards compatible.

## Related PRs
This PR supersedes and makes redundant:
- #24 (same changes, but had merge conflicts)
- #23, #21, #20, #18, #17 (older partial security updates)

Those PRs can be closed after this one is merged.